### PR TITLE
Github action syntax check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,10 +34,10 @@ runs: # Required
     - name: check if has path directory
       run: |
         path=${{ inputs.path }}
-        if [ -d $path ]; then
+        if [ -d "$path" ]; then
           echo "[INFO] $path already exists."
         else 
-          mkdir $path
+          mkdir -p "$path"
           echo "[INFO] $path has already been created."
         fi
       shell: bash


### PR DESCRIPTION
Optimize directory creation in `action.yml` to improve robustness.

The original `mkdir $path` command was not robust against paths containing spaces or when parent directories did not exist. Adding `-p` ensures parent directories are created as needed, and quoting `$path` handles spaces correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-19d126ac-344f-4d9e-92ab-d842ffc71a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-19d126ac-344f-4d9e-92ab-d842ffc71a46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

